### PR TITLE
Fix filter bug when there are no contacts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -86,7 +86,7 @@ export default class App extends React.Component<AppProps, AppState> {
                 !repo.name.toLowerCase().includes(filterWord) &&
                 !repo.description.toLowerCase().includes(filterWord) &&
                 repo.labels.filter((label) => label.toLowerCase().includes(filterWord)).length == 0 &&
-                (!!repo.contacts && repo.contacts.filter((contact) => contact.username.toLowerCase().includes(filterWord)).length == 0)) {
+                (!!repo.contacts ? repo.contacts.filter((contact) => contact.username.toLowerCase().includes(filterWord)).length == 0 : true)) {
                 return false
             }
         }


### PR DESCRIPTION
Regardless of the filter typed, we were always returning any repo which had no contacts